### PR TITLE
Added ARM64 jobs to .travis.yml file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,8 @@
 dist: xenial
 language: go
+arch:
+  - amd64
+  - arm64
 addons:
   apt:
     packages:

--- a/cli/test-data/output/TestLoadIncrementer/plugin_providers.upload.incrementer.from/bin/linux/arm64/incrementer/stdout.expect
+++ b/cli/test-data/output/TestLoadIncrementer/plugin_providers.upload.incrementer.from/bin/linux/arm64/incrementer/stdout.expect
@@ -1,0 +1,2 @@
+RE:
+  "path": "incrementer",


### PR DESCRIPTION
Hi

Package Owner: Prakriti Chauhan

PR change Details:
$ Patch Details: Following files has been modified :

.travis.yml: added arch: arm64 
Created a folder named "arm64/incrementer/" and added a file named "stdout.expect" inside that folder 
File Link- https://github.com/odidev/provision/blob/local_pr/cli/test-data/output/TestLoadIncrementer/plugin_providers.upload.incrementer.from/bin/linux/arm64/incrementer/stdout.expect

$ Testing Detail :
Travis Link- https://travis-ci.com/github/prakritichauhan07/provision/builds/183672907

$ PR Description: Here is my commit message :
Added ARM64 jobs to .travis.yml file
Signed-off-by: odidev odidev@puresoftware.com

Here is my PR description:
Patch Details: Following files has been modified :

.travis.yml: added arch: arm64 
Created a folder named "arm64/incrementer/" and added a file named "stdout.expect" inside that folder 
File Link- https://github.com/prakriti07/provision/tree/v4/cli/test-data/output/TestLoadIncrementer/plugin_providers.upload.incrementer.from/bin/linux/arm64/incrementer

$ Peer Reviewer: Pruthvi Teja
$ Reviewer: Rajeev Nayan

Thanks
Prakriti Chauhan